### PR TITLE
Use relative path for realtime.js.

### DIFF
--- a/static/files/index.html
+++ b/static/files/index.html
@@ -63,7 +63,7 @@
 		<script src="js/vendor/query-string.js"></script>
 		<script src="js/vendor/angular.min.js"></script>
 		<script src="js/vendor/moment.min.js"></script>
-		<script src="/realtime.js"></script>
+		<script src="realtime.js"></script>
 		<script>window.app = window.angular.module('app', []);</script>
 		<script src="js/config-controller.js"></script>
 		<script src="js/omni-controller.js"></script>

--- a/static/files/js/run.js
+++ b/static/files/js/run.js
@@ -6,7 +6,7 @@ app.run(function($rootScope, search, api) {
   var $scope = window.scope = $rootScope;
 
   //link up to angular
-	var rt = realtime("/realtime");
+	var rt = realtime("realtime");
 	$scope.state = {};
 	rt.add("state", $scope.state, function() {
 		$scope.$apply();


### PR DESCRIPTION
An absolute path was used for including the `realtime.js` file, which broke virtualhost configurations making cloud-torrent accessible under a path, such as `http://example.com/torrent`.

This PR fixes the above described issue.
