### PR TITLE
Fix failing to load 404 torrent

### DIFF
--- a/server/server_api.go
+++ b/server/server_api.go
@@ -34,6 +34,11 @@ func (s *Server) api(r *http.Request) error {
 		if err != nil {
 			return fmt.Errorf("Invalid remote torrent URL: %s (%s)", err, url)
 		}
+
+		if remote.StatusCode != 200 {
+			return fmt.Errorf("Invalid response requesting torrent URL: %s (%s)", remote.Status, url)
+		}
+
 		//TODO enforce max body size (32k?)
 		data, err = ioutil.ReadAll(remote.Body)
 		if err != nil {


### PR DESCRIPTION
If loading the torrent doesn't return 200, fail the fetch.

For example loading http://releases.ubuntu.com/18.04/not-found returns a HTTP 404, so handle that nicely.