### PR TITLE
Make final docker image smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,25 @@
-FROM alpine:edge
-LABEL maintainer="dev@jpillora.com"
+FROM golang:1.12.6-alpine as builder
 # prepare go env
 ENV GOPATH /go
 ENV NAME cloud-torrent
 ENV PACKAGE github.com/jpillora/$NAME
 ENV PACKAGE_DIR $GOPATH/src/$PACKAGE
-ENV GOLANG_VERSION 1.9.1
-ENV GOLANG_SRC_URL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz
-ENV GOLANG_SRC_SHA256 a84afc9dc7d64fe0fa84d4d735e2ece23831a22117b50dafc75c1484f1cb550e
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 ENV CGO_ENABLED 0
-# in one step (to prevent creating superfluous layers):
-# 1. fetch and install temporary build programs,
-# 2. build cloud-torrent alpine binary
-# 3. remove build programs
-RUN set -ex \
-	&& apk update \
-	&& apk add ca-certificates \
-	&& apk add --no-cache --virtual .build-deps \
-	bash \
-	gcc \
-	musl-dev \
-	openssl \
-	git \
-	go \
-	curl \
-	&& curl -s https://raw.githubusercontent.com/docker-library/golang/221ee92559f2963c1fe55646d3516f5b8f4c91a4/1.9/alpine3.6/no-pic.patch -o /no-pic.patch \
-	&& cat /no-pic.patch \
-	&& export GOROOT_BOOTSTRAP="$(go env GOROOT)" \
-	&& wget -q "$GOLANG_SRC_URL" -O golang.tar.gz \
-	&& echo "$GOLANG_SRC_SHA256  golang.tar.gz" | sha256sum -c - \
-	&& tar -C /usr/local -xzf golang.tar.gz \
-	&& rm golang.tar.gz \
-	&& cd /usr/local/go/src \
-	&& patch -p2 -i /no-pic.patch \
-	&& ./make.bash \
-	&& mkdir -p $PACKAGE_DIR \
-	&& git clone https://$PACKAGE.git $PACKAGE_DIR \
-	&& cd $PACKAGE_DIR \
-	&& go build -ldflags "-X main.VERSION=$(git describe --abbrev=0 --tags)" -o /usr/local/bin/$NAME \
-	&& apk del .build-deps \
-	&& rm -rf /no-pic.patch $GOPATH /usr/local/go
-#run!
-ENTRYPOINT ["cloud-torrent"]
+
+RUN apk add --no-cache ca-certificates bash gcc musl-dev openssl git go curl
+RUN	git clone https://$PACKAGE.git $PACKAGE_DIR
+RUN	cd $PACKAGE_DIR && go build -ldflags "-X main.VERSION=$(git describe --abbrev=0 --tags)" -o /usr/local/bin/$NAME
+
+
+
+FROM alpine:3.9
+LABEL maintainer="jpillora <dev@jpillora.com>"
+
+RUN apk add --no-cache ca-certificates openssl curl
+
+COPY --from=builder /usr/local/bin/$NAME /
+
+WORKDIR downloads
+
+ENTRYPOINT ["/cloud-torrent"]


### PR DESCRIPTION
Use go 1.12.6 as a builder image then copy final binary to fresh alpine
3.9 image for use