### PR TITLE
update docker image to ghcr.io in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,8 @@ curl https://i.jpillora.com/cloud-torrent! | bash
 
 **Docker**
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/jpillora/cloud-torrent.svg)][dockerhub]
-
-[dockerhub]: https://hub.docker.com/r/jpillora/cloud-torrent/
-
 ``` sh
-$ docker run -d -p 3000:3000 -v /path/to/my/downloads:/downloads jpillora/cloud-torrent
+$ docker run -d -p 3000:3000 -v /path/to/my/downloads:/downloads ghcr.io/jpillora/cloud-torrent
 ```
 
 **Source**


### PR DESCRIPTION
Following this comment: https://github.com/jpillora/cloud-torrent/issues/345#issuecomment-2842469209

The Docker command in the current README.md uses the Docker Hub image jpillora/cloud-torrent:latest, which is 7 years old. This PR updates the image reference to ghcr.io/jpillora/cloud-torrent:latest, which is the actively maintained version hosted on GitHub Container Registry.